### PR TITLE
chore: use attach instead of starting a new instance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,20 +10,15 @@
             "autoAttachChildProcesses": true
         },
         {
-            "name": "Debug Renderer Process",
+            // Needs to start "Debug Main Process" first
+            "name": "Attach Debugger Renderer Process",
+            "request": "attach",
             "type": "chrome",
-            "request": "launch",
-            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-            "windows": {
-                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
-            },
-            "runtimeArgs": [
-              "${workspaceRoot}/packages/main/dist/index.cjs",
-              "--enable-logging",
-              "--remote-debugging-port=9222"
-            ],
+            "port": 9223,
             "sourceMaps": true,
-            "webRoot": "${workspaceRoot}/packages/"
-        }
+            "webRoot": "${workspaceRoot}/packages/",
+            "timeout": 30000
+          },
     ],
 }
+

--- a/scripts/watch.cjs
+++ b/scripts/watch.cjs
@@ -71,7 +71,7 @@ const setupMainPackageWatcher = ({ config: { server } }) => {
         spawnProcess = null;
       }
 
-      spawnProcess = spawn(String(electronPath), ['.'], { env: { ...process.env, ELECTRON_IS_DEV: 1 } });
+      spawnProcess = spawn(String(electronPath), [ '--remote-debugging-port=9223', '.'], { env: { ...process.env, ELECTRON_IS_DEV: 1 } });
 
       spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), { timestamp: true }));
       spawnProcess.stderr.on('data', d => {


### PR DESCRIPTION
### What does this PR do?
Use attach instead of starting a new electron process for the renderer


Change-Id: Id10cebc24476df53cac69125544b115157a707a2
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
